### PR TITLE
Make deepcopy work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MistyClosures"
 uuid = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"
 authors = ["Will Tebbutt", "Frames White", "Hong Ge"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1.10"

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -12,6 +12,11 @@ MistyClosure(ir::IRCode; kwargs...) =  MistyClosure(OpaqueClosure(ir; kwargs...)
 
 (mc::MistyClosure)(x::Vararg{Any, N}) where {N} = mc.oc(x...)
 
+# You can't deepcopy an `IRCode` because it contains a module.
+function Base.deepcopy_internal(x::T, dict::IdDict) where {T<:MistyClosure}
+    return T(Base.deepcopy_internal(x.oc, dict), x.ir)
+end
+
 export MistyClosure
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,7 @@ using Core: OpaqueClosure
     # Default constructor.
     mc_default = MistyClosure(OpaqueClosure(ir; do_compile=true), ir)
     @test @inferred(mc_default(5.0) == sin(5.0))
+
+    # deepcopy
+    @test deepcopy(mc) isa typeof(mc)
 end


### PR DESCRIPTION
You can't deepcopy an `IRCode`. Consequently, you need a specialised version of `deepcopy`. This at least partly addresses https://github.com/compintell/Tapir.jl/issues/193