### PR TITLE
Implement better printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MistyClosures"
 uuid = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"
 authors = ["Will Tebbutt", "Frames White", "Hong Ge"]
-version = "1.0.1"
+version = "1.0.2"
 
 [compat]
 julia = "1.10"

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -3,6 +3,8 @@ module MistyClosures
 using Core: OpaqueClosure
 using Core.Compiler: IRCode
 
+import Base: show
+
 struct MistyClosure{Toc<:OpaqueClosure}
     oc::Toc
     ir::IRCode
@@ -15,6 +17,16 @@ MistyClosure(ir::IRCode; kwargs...) =  MistyClosure(OpaqueClosure(ir; kwargs...)
 # You can't deepcopy an `IRCode` because it contains a module.
 function Base.deepcopy_internal(x::T, dict::IdDict) where {T<:MistyClosure}
     return T(Base.deepcopy_internal(x.oc, dict), x.ir)
+end
+
+# Don't print out the IRCode object, because this tends to pollute the REPL. Just make it
+# clear that this is a MistyClosure, which contains an OpaqueClosure.
+show(io::IO, mime::MIME"text/plain", mc::MistyClosure) = _show_misty_closure(io, mime, mc)
+show(io::IO, mc::MistyClosure) = _show_misty_closure(io, MIME"text/plain"(), mc)
+
+function _show_misty_closure(io::IO, mime::MIME"text/plain", mc::MistyClosure)
+    print(io, "MistyClosure ")
+    show(io, mime, mc.oc)
 end
 
 export MistyClosure

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,9 @@ using Core: OpaqueClosure
 
     # deepcopy
     @test deepcopy(mc) isa typeof(mc)
+
+    # printing -- we shouldn't see the IRCode, because it's often quite a lot.
+    io = IOBuffer()
+    show(io, mc)
+    @test String(take!(io)) == "MistyClosure (::Float64)::Float64->◌"
 end


### PR DESCRIPTION
Current printing uses default, which prints the entire `IRCode`, which has a tendency to be long and to fill up the REPL when you don't want it to. This PR prints only the `OpaqueClosure`, which prints very nicely. See test for example output.