### PR TITLE
Enable Captures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MistyClosures"
 uuid = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"
 authors = ["Will Tebbutt", "Frames White", "Hong Ge"]
-version = "1.0.2"
+version = "1.0.3"
 
 [compat]
 julia = "1.10"

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -10,7 +10,9 @@ struct MistyClosure{Toc<:OpaqueClosure}
     ir::IRCode
 end
 
-MistyClosure(ir::IRCode; kwargs...) =  MistyClosure(OpaqueClosure(ir; kwargs...), ir)
+function MistyClosure(ir::IRCode, env...; kwargs...)
+    return MistyClosure(OpaqueClosure(ir, env...; kwargs...), ir)
+end
 
 (mc::MistyClosure)(x::Vararg{Any, N}) where {N} = mc.oc(x...)
 


### PR DESCRIPTION
In the current version of this package, you can't actually straightforwardly pass in environment variables to the preferred constructor, which is was quite an oversight on my part! This PR enables this.