### PR TITLE
compat fix for Julia 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - 'lts'
+          - '1.11'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'lts'
+          - '1.10'
           - '1.11'
           - 'pre'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MistyClosures"
 uuid = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"
 authors = ["Will Tebbutt", "Frames White", "Hong Ge"]
-version = "2.0.0"
+version = "2.1.0"
 
 [compat]
 julia = "1.10"

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -16,17 +16,7 @@ struct MistyClosure{Toc<:OpaqueClosure}
 end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
-    @static if VERSION ≥ v"1.12.0-"
-        # replace `argtypes[1]` with `Tuple{} if it is `Core.Const(sin)`
-        # do nothing if it is a callable object, or `Tuple{}`
-        ir.argtypes[1] = if ir.argtypes[1] isa Core.Const 
-            Tuple{} 
-        elseif ir.argtypes[1] != Tuple{}
-            Tuple{ir.argtypes[1]}
-        else
-            ir.argtypes[1]
-        end
-    end
+    ir.argtypes[1] isa Tuple || error("sigtype mismatch in optimized misty closure")
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))
 end
 

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -16,6 +16,7 @@ struct MistyClosure{Toc<:OpaqueClosure}
 end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
+    ir.argtypes = Tuple{}
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))
 end
 

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -16,7 +16,9 @@ struct MistyClosure{Toc<:OpaqueClosure}
 end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
-    ir.argtypes = Tuple{}
+    @static if VERSION ≥ v"1.12"
+        ir.argtypes = Tuple{}
+    end
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))
 end
 

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -16,8 +16,16 @@ struct MistyClosure{Toc<:OpaqueClosure}
 end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
-    @static if VERSION ≥ v"1.12.0-beta1"
-        ir.argtypes[1] = Tuple{}
+    @static if VERSION ≥ v"1.12.0-"
+        # replace `argtypes[1]` with `Tuple{} if it is `Core.Const(sin)`
+        # do nothing if it is a callable object, or `Tuple{}`
+        ir.argtypes[1] = if ir.argtypes[1] isa Core.Const 
+            Tuple{} 
+        elseif ir.argtypes[1] != Tuple{}
+            Tuple{ir.argtypes[1]}
+        else
+            ir.argtypes[1]
+        end
     end
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))
 end

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -17,7 +17,7 @@ end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
     @static if VERSION ≥ v"1.12"
-        ir.argtypes = Tuple{}
+        ir.argtypes[1] = Tuple{}
     end
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))
 end

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -16,7 +16,6 @@ struct MistyClosure{Toc<:OpaqueClosure}
 end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
-    ir.argtypes[1] isa Tuple || error("sigtype mismatch in optimized misty closure")
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))
 end
 

--- a/src/MistyClosures.jl
+++ b/src/MistyClosures.jl
@@ -16,7 +16,7 @@ struct MistyClosure{Toc<:OpaqueClosure}
 end
 
 function MistyClosure(ir::IRCode, env...; kwargs...)
-    @static if VERSION ≥ v"1.12"
+    @static if VERSION ≥ v"1.12.0-beta1"
         ir.argtypes[1] = Tuple{}
     end
     return MistyClosure(OpaqueClosure(ir, env...; kwargs...), Ref(ir))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ end
 
 @testset "MistyClosures.jl" begin
     ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64}) |> only |> first
-    ir_foo.argtypes[1] = Tuple{}
+    ir.argtypes[1] = Tuple{}
 
     # Recommended constructor.
     mc = MistyClosure(ir; do_compile=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ end
 (f::Foo)(y) = f.x * y
 
 function _fix_ir(ir)
-    _ir = copy(ir)
     @static if VERSION ≥ v"1.12.0-beta1" 
+        _ir = copy(ir)
         _ir.argtypes[1] = Tuple{}
     end
     _ir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ function _fix_ir!(ir)
             ir.argtypes[1]
         end
     end
+    ir
 end
 
 @testset "MistyClosures.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,12 +24,12 @@ end
 
     # Recommended constructor with env.
     ir_foo = Base.code_ircode_by_type(Tuple{Tuple{Foo}, Float64}) |> only |> first
-    mc_with_env = MistyClosure(ir_foo, 5.0; do_compile=true)
-    @test @inferred(mc_with_env(4.0)) == Foo(5.0)(4.0)
+    mc_with_env = MistyClosure(ir_foo, Foo(5.0); do_compile=true)
+    @test @inferred(mc_with_env(4.0)) == (Foo(5.0),)(4.0)
 
     # Default constructor with env.
-    mc_env_default = MistyClosure(OpaqueClosure(ir_foo, 4.0; do_compile=true), Ref(ir_foo))
-    @test @inferred(mc_env_default(5.0) == Foo(5.0)(4.0))
+    mc_env_default = MistyClosure(OpaqueClosure(ir_foo, Foo(5.0); do_compile=true), Ref(ir_foo))
+    @test @inferred(mc_env_default(5.0) == (Foo(5.0),)(4.0))
 
     # deepcopy
     @test deepcopy(mc) isa typeof(mc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,5 +37,9 @@ end
     # printing -- we shouldn't see the IRCode, because it's often quite a lot.
     io = IOBuffer()
     show(io, mc)
-    @test String(take!(io)) == "MistyClosure (::Float64)::Float64->◌"
+    @static if VERSION >= v"1.12-"
+        @test String(take!(io)) == "MistyClosure (::Float64)->◌::Float64"
+    else
+        @test String(take!(io)) == "MistyClosure (::Float64)::Float64->◌"
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,8 @@ end
     @test @inferred(mc(5.0)) == sin(5.0)
 
     # Default constructor.
-    mc_default = MistyClosure(OpaqueClosure(_fix_ir(ir); do_compile=true), Ref(_ir))
+    ir_fixed = _fix_ir(ir)
+    mc_default = MistyClosure(OpaqueClosure(ir_fixed; do_compile=true), Ref(ir_fixed))
     @test @inferred(mc_default(5.0) == sin(5.0))
 
     # Recommended constructor with env.
@@ -33,7 +34,8 @@ end
     @test @inferred(mc_with_env(4.0)) == Foo(5.0)(4.0)
 
     # Default constructor with env.
-    mc_env_default = MistyClosure(OpaqueClosure(_fix_ir(ir_foo), 4.0; do_compile=true), Ref(ir_foo))
+    ir_foo_fixed = _fix_ir(ir_foo)
+    mc_env_default = MistyClosure(OpaqueClosure(ir_foo_fixed, 4.0; do_compile=true), Ref(ir_foo_fixed))
     @test @inferred(mc_env_default(5.0) == Foo(5.0)(4.0))
 
     # deepcopy

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,9 @@ end
 (f::Foo)(y) = f.x * y
 
 function _fix_ir(ir)
-    @static if VERSION ≥ v"1.12.0-beta1" 
-        ir.argtypes[1] = Tuple{}
+    @static if VERSION ≥ v"1.12.0-"
+        # replace `argtypes[1]` if it is not `Core.Const(sin)`, e.g., it is a callable object
+        ir.argtypes[1] = ir.argtypes[1] isa Core.Const ? Tuple{} : Tuple{ir.argtypes[1]}
     end
     return ir
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 
     # Default constructor with env.
     mc_env_default = MistyClosure(OpaqueClosure(ir_foo, Foo(5.0); do_compile=true), Ref(ir_foo))
-    @test @inferred(mc_env_default(5.0) == (Foo(5.0),)(4.0))
+    @test @inferred(mc_env_default(4.0)) == (Foo(5.0),)(4.0)
 
     # deepcopy
     @test deepcopy(mc) isa typeof(mc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,12 +10,9 @@ end
 
 function _fix_ir(ir)
     @static if VERSION ≥ v"1.12.0-beta1" 
-        _ir = copy(ir)
-        _ir.argtypes[1] = Tuple{}
-        return _ir
-    else
-        return ir
+        ir.argtypes[1] = Tuple{}
     end
+    return ir
 end
 
 @testset "MistyClosures.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
     @test @inferred(mc_default(5.0) == sin(5.0))
 
     # Recommended constructor with env.
-    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64}) |> only |> first
+    ir_foo = Base.code_ircode_by_type(Tuple{Tuple{Foo}, Float64}) |> only |> first
     mc_with_env = MistyClosure(ir_foo, 5.0; do_compile=true)
     @test @inferred(mc_with_env(4.0)) == Foo(5.0)(4.0)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,24 +22,22 @@ function _fix_ir!(ir)
 end
 
 @testset "MistyClosures.jl" begin
-    ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64}) |> only |> first
+    ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64}) |> only |> first |> _fix_ir!
 
     # Recommended constructor.
     mc = MistyClosure(ir; do_compile=true)
     @test @inferred(mc(5.0)) == sin(5.0)
 
     # Default constructor.
-    _fix_ir!(ir)
     mc_default = MistyClosure(OpaqueClosure(ir; do_compile=true), Ref(ir))
     @test @inferred(mc_default(5.0) == sin(5.0))
 
     # Recommended constructor with env.
-    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64}) |> only |> first
+    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64}) |> only |> first |> _fix_ir!
     mc_with_env = MistyClosure(ir_foo, 5.0; do_compile=true)
     @test @inferred(mc_with_env(4.0)) == Foo(5.0)(4.0)
 
     # Default constructor with env.
-    _fix_ir!(ir_foo)
     mc_env_default = MistyClosure(OpaqueClosure(ir_foo, 4.0; do_compile=true), Ref(ir_foo))
     @test @inferred(mc_env_default(5.0) == Foo(5.0)(4.0))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ function _fix_ir(ir)
 end
 
 @testset "MistyClosures.jl" begin
-    ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64})[1][1]
+    ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64}) |> only |> first
 
     # Recommended constructor.
     mc = MistyClosure(ir; do_compile=true)
@@ -28,7 +28,7 @@ end
     @test @inferred(mc_default(5.0) == sin(5.0))
 
     # Recommended constructor with env.
-    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64})[1][1]
+    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64}) |> only |> first
     mc_with_env = MistyClosure(ir_foo, 5.0; do_compile=true)
     @test @inferred(mc_with_env(4.0)) == Foo(5.0)(4.0)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ end
 
 (f::Foo)(y) = f.x * y
 
-function _fix_ir!(ir)
+function _fix_argtypes!(ir)
     @static if VERSION ≥ v"1.12.0-"
         # replace `argtypes[1]` if it is not `Core.Const(sin)`, e.g., it is a callable object, or `Tuple{}`
         ir.argtypes[1] = if ir.argtypes[1] isa Core.Const 
@@ -23,7 +23,7 @@ function _fix_ir!(ir)
 end
 
 @testset "MistyClosures.jl" begin
-    ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64}) |> only |> first |> _fix_ir!
+    ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64}) |> only |> first |> _fix_argtypes!
 
     # Recommended constructor.
     mc = MistyClosure(ir; do_compile=true)
@@ -34,7 +34,7 @@ end
     @test @inferred(mc_default(5.0) == sin(5.0))
 
     # Recommended constructor with env.
-    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64}) |> only |> first |> _fix_ir!
+    ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64}) |> only |> first |> _fix_argtypes!
     mc_with_env = MistyClosure(ir_foo, 5.0; do_compile=true)
     @test @inferred(mc_with_env(4.0)) == Foo(5.0)(4.0)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,10 @@ function _fix_ir(ir)
     @static if VERSION ≥ v"1.12.0-beta1" 
         _ir = copy(ir)
         _ir.argtypes[1] = Tuple{}
+        return _ir
+    else
+        return ir
     end
-    _ir
 end
 
 @testset "MistyClosures.jl" begin


### PR DESCRIPTION
Fix https://github.com/chalk-lab/MistyClosures.jl/issues/10


Julia's 1.12 update introduced stricter type checking for `OpaqueClosure`, which now correctly enforces that the closed-over variables must be passed within a `Tuple`. Previously, code could run by chance on version 1.11 because the memory layout of the closed-over object and the expected `Tuple` were the same, leading to a dangerous and incorrect execution. For example, to fix the issue, the callable object's first argument must be explicitly defined as a `Tuple{Foo}`, allowing it to correctly access the field `f[1].x` instead of `f.x`.

To illustrate how dangerous the behaviour in 1.11 was, consider this example (courtesy to @willtebbutt) 

```julia
julia> module MWE

       struct Foo
           x::Float64
       end

       (f::Foo)(y) = f.x * y

       f = Foo(4.0)
       ir_foo = Base.code_ircode_by_type(Tuple{Foo, Float64})[1][1];
       # ir_foo.argtypes[1] = Tuple{ir_foo.argtypes[1]}
       oc = Core.OpaqueClosure(ir_foo, 3, f; do_compile=true)
       @show oc(3.0)

       end
WARNING: replacing module MWE.
oc(3.0) = 4.4e-323
Main.MWE
```

This output is what you would get when you call `Core.bitcast(Float64, 3) * 3.0`, highlighting that the code was incorrectly using the closed-over integer `3` instead of the `Foo` object.


For example, to fix the issue, the callable object’s first argument must be explicitly defined as a `Tuple{Foo}`, allowing it to correctly access the field `f[1].x` instead of `f.x`.
The example below works correctly for both Julia 1.11 and 1.12:

```julia
julia> struct Foo
           x::Float64
       end

julia> (f::Tuple{Foo})(y) = f[1].x * y

julia> ir_foo = Base.code_ircode_by_type(Tuple{Tuple{Foo}, Float64})[1][1]
1 1 ─ %1 = $(Expr(:boundscheck, true))::Bool                                                              │╻ getindex
  │   %2 =   builtin Base.getfield(_1, 1, %1)::Foo                                                        ││
  │   %3 =   builtin Base.getfield(%2, :x)::Float64                                                       │╻ getproperty
  │   %4 = intrinsic Base.mul_float(%3, _2)::Float64                                                      │╻ *
  └──      return %4                                                                                      ││
                                                                                                            

julia> f = Foo(4.0)
Foo(4.0)

julia> oc = Core.OpaqueClosure(ir_foo, f; do_compile=true)
(::Float64)->◌::Float64

julia> oc(4.)
16.0
```